### PR TITLE
Rank Names in Stats fixed

### DIFF
--- a/app/Http/Controllers/StatistkenController.php
+++ b/app/Http/Controllers/StatistkenController.php
@@ -17,8 +17,12 @@ class StatistkenController extends Controller
             // Add - to uuid
             $user->formattedUUID = substr($user->uuid, 0, 8).'-'.substr($user->uuid, 8, 4).'-'.substr($user->uuid, 12, 4).'-'.substr($user->uuid, 16, 4).'-'.substr($user->uuid, 20, 12);
             $userLP = DB::selectOne('SELECT * FROM luckperms_players WHERE `uuid` = ?', [$user->formattedUUID]);
-            $user->rank = Str::title($userLP->primary_group);
-            $user->name = Str::title($userLP->username);
+            $user->rank = match ($userLP->primary_group) {
+                'webdev' => 'Web-Dev',
+                'eventmanager' => 'EventManager',
+                default => Str::title($userLP->primary_group),
+            };
+            $user->name = $user->username;
 
             $prefixPermission = DB::selectOne('SELECT `name`, `permission` FROM luckperms_group_permissions WHERE `permission` LIKE "prefix.%" AND `name` = ?', [$userLP->primary_group]);
             $splitted = explode('.', $prefixPermission->permission);


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ba59f4</samp>

Use match expression to format user ranks and use server username for user name in `StatistkenController.php`. These changes improve the user statistics display on the website.

### WHY

Fixed #70 

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ba59f4</samp>

*  Assign `rank` and `name` attributes of `$user` object using match expression and `$user->username` property respectively ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/73/files?diff=unified&w=0#diff-cba6fdfc9a2c31b44c820c572ecbba6e969ec334f10b0739d52a344eb2478ceeL20-R25))
*  Replace Str::title function with match expression to customize rank display ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/73/files?diff=unified&w=0#diff-cba6fdfc9a2c31b44c820c572ecbba6e969ec334f10b0739d52a344eb2478ceeL20-R25))
*  Use `$user->username` instead of `$userLP->username` to match server name ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/73/files?diff=unified&w=0#diff-cba6fdfc9a2c31b44c820c572ecbba6e969ec334f10b0739d52a344eb2478ceeL20-R25))
