### PR TITLE
refactor(app_body.js): use plural form of time units when appropriate…

### DIFF
--- a/resources/js/app_body.js
+++ b/resources/js/app_body.js
@@ -4,15 +4,17 @@ images.forEach((image) => {
     image.draggable = false;
 });
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
     updateTimeElementsWithTimeDifference();
 });
 
 function updateTimeElementsWithTimeDifference() {
-    const timeElements = document.querySelectorAll('time[data-startdate][data-enddate]');
+    const timeElements = document.querySelectorAll(
+        "time[data-startdate][data-enddate]"
+    );
     timeElements.forEach((timeElement) => {
-        const startDateString = timeElement.getAttribute('data-startdate');
-        const endDateString = timeElement.getAttribute('data-enddate');
+        const startDateString = timeElement.getAttribute("data-startdate");
+        const endDateString = timeElement.getAttribute("data-enddate");
         const startDate = new Date(startDateString);
         const endDate = new Date(endDateString);
         const now = new Date();
@@ -23,32 +25,43 @@ function updateTimeElementsWithTimeDifference() {
 
         if (now < startDate) {
             differenceInSeconds = Math.round((startDate - now) / 1000);
-            prefix = 'Startet in';
-            title = 'BALD:';
-            colors = ['bg-gray2-100', 'border-gray2-200'];
+            prefix = "Startet in";
+            title = "BALD:";
+            colors = ["bg-gray2-100", "border-gray2-200"];
             timeElement.title = formatFullDate(startDate);
         } else {
             differenceInSeconds = Math.round((endDate - now) / 1000);
-            prefix = 'Endet in';
-            title = 'LIVE:';
-            colors = ['bg-red-800', 'border-red-400'];
+            prefix = "Endet in";
+            title = "LIVE:";
+            colors = ["bg-red-800", "border-red-400"];
             timeElement.title = formatFullDate(endDate);
         }
 
-        for(const color of colors) {
-            document.getElementById('event-title').parentElement.classList.add(color);
+        for (const color of colors) {
+            document
+                .getElementById("event-title")
+                .parentElement.classList.add(color);
         }
 
-        document.getElementById('event-title').innerText = title;
+        document.getElementById("event-title").innerText = title;
 
-        const timeDifferenceString = getTimeDifferenceString(differenceInSeconds, prefix);
+        const timeDifferenceString = getTimeDifferenceString(
+            differenceInSeconds,
+            prefix
+        );
         timeElement.textContent = timeDifferenceString;
     });
 }
 
 function formatFullDate(date) {
-    const options = { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' };
-    const formattedDate = date.toLocaleDateString('de-DE', options);
+    const options = {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    };
+    const formattedDate = date.toLocaleDateString("de-DE", options);
     return formattedDate;
 }
 
@@ -58,12 +71,20 @@ function getTimeDifferenceString(differenceInSeconds, prefix) {
     const differenceInDays = Math.round(differenceInHours / 24);
 
     if (differenceInSeconds < 60) {
-        return `${prefix} ${differenceInSeconds} Sekunde${differenceInSeconds > 1 ? 'n' : ''}`;
+        return `${prefix} ${differenceInSeconds} Sekunde${
+            differenceInSeconds > 1 ? "n" : ""
+        }`;
     } else if (differenceInMinutes < 60) {
-        return `${prefix} ${differenceInMinutes} Minute${differenceInMinutes > 1 ? 'n' : ''}`;
+        return `${prefix} ${differenceInMinutes} Minute${
+            differenceInMinutes > 1 ? "n" : ""
+        }`;
     } else if (differenceInHours < 24) {
-        return `${prefix} ${differenceInHours} Stunde${differenceInHours > 1 ? 'n' : ''}`;
+        return `${prefix} ${differenceInHours} Stunde${
+            differenceInHours > 1 ? "n" : ""
+        }`;
     } else {
-        return `${prefix} ${differenceInDays} Tag${differenceInDays > 1 ? 'en' : ''}`;
+        return `${prefix} ${differenceInDays} Tag${
+            differenceInDays > 1 ? "en" : ""
+        }`;
     }
 }

--- a/resources/js/app_body.js
+++ b/resources/js/app_body.js
@@ -58,12 +58,12 @@ function getTimeDifferenceString(differenceInSeconds, prefix) {
     const differenceInDays = Math.round(differenceInHours / 24);
 
     if (differenceInSeconds < 60) {
-        return `${prefix} ${differenceInSeconds} Sekunden`;
+        return `${prefix} ${differenceInSeconds} Sekunde${differenceInSeconds > 1 ? 'n' : ''}`;
     } else if (differenceInMinutes < 60) {
-        return `${prefix} ${differenceInMinutes} Minuten`;
+        return `${prefix} ${differenceInMinutes} Minute${differenceInMinutes > 1 ? 'n' : ''}`;
     } else if (differenceInHours < 24) {
-        return `${prefix} ${differenceInHours} Stunden`;
+        return `${prefix} ${differenceInHours} Stunde${differenceInHours > 1 ? 'n' : ''}`;
     } else {
-        return `${prefix} ${differenceInDays} Tagen`;
+        return `${prefix} ${differenceInDays} Tag${differenceInDays > 1 ? 'en' : ''}`;
     }
 }


### PR DESCRIPTION
… in getTimeDifferenceString function

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57f46d7</samp>

Improved German translation of time differences in `app_body.js`. Added singular and plural forms of time units to `getTimeDifferenceString` function.

### WHY

Grammar was not in correct format.

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57f46d7</samp>

*  Improve the German translation of the time difference strings by adding singular and plural forms of the units of time ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/74/files?diff=unified&w=0#diff-f910ea67ba8da722aa5c8150a8149cceb5d134644485815090e224b7d79a2691L61-R67))
