### PR TITLE
Added PrestigeLevel Sorting

### DIFF
--- a/app/Http/Controllers/StatistkenController.php
+++ b/app/Http/Controllers/StatistkenController.php
@@ -11,7 +11,7 @@ class StatistkenController extends Controller
 {
     public function index()
     {
-        $topUsers = DB::select('SELECT *, HEX(unique_id) AS uuid FROM `realm_players` WHERE `xp` > 0 ORDER BY `xp` DESC LIMIT 12');
+        $topUsers = DB::select('SELECT *, HEX(unique_id) AS uuid FROM `realm_players` WHERE `xp` > 0 ORDER BY `prestigeLevel` DESC, `xp` DESC LIMIT 12');
 
         $topUsers = array_map(function ($user) {
             // Add - to uuid

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -21,6 +21,9 @@
                                             <span class="px-2 py-1 text-white text-xs font-medium rounded-full" style="background-color: {{ $user->color }}">{{ $user->rank }}</span>
                                         </dd>
                                         <dd class="mt-3">
+                                            <span class="px-2 py-1 text-white text-xs font-medium rounded-full">{{ $user->prestigeLevel }} PrestigeLevel</span>
+                                        </dd>
+                                        <dd class="mt-3">
                                             <span class="px-2 py-1 text-white text-xs font-medium rounded-full">{{ $user->xp }} XP</span>
                                         </dd>
                                         <dd class="mt-3">


### PR DESCRIPTION
Added PrestigeLevel Sorting

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9af114e</samp>

This pull request updates the stats page to show the users' prestige levels, a new feature of the game. It changes the `StatistkenController.php` file to sort the users by prestige and xp, and the `stats.blade.php` file to display a prestige badge.

### WHY

New Feature on the Server

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9af114e</samp>

*  Modify the SQL query for fetching the top users to order them by prestige level and then by xp ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/80/files?diff=unified&w=0#diff-cba6fdfc9a2c31b44c820c572ecbba6e969ec334f10b0739d52a344eb2478ceeL14-R14))
*  Add a badge to the HTML template for displaying the top users that shows their prestige level ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/80/files?diff=unified&w=0#diff-1606e1d078b3556b885ba3d1ff991c833c059dc678d9de3e66b040e9b804428fR24-R26))
