### PR TITLE
#79 Add Prestige to XP and sort by Prestige

### DIFF
--- a/app/Http/Controllers/StatistkenController.php
+++ b/app/Http/Controllers/StatistkenController.php
@@ -11,7 +11,7 @@ class StatistkenController extends Controller
 {
     public function index()
     {
-        $topUsers = DB::select('SELECT *, HEX(unique_id) AS uuid FROM `realm_players` WHERE `xp` > 0 ORDER BY `xp` DESC LIMIT 12');
+        $topUsers = DB::select('SELECT *, HEX(unique_id) AS uuid FROM `realm_players` WHERE `xp` > 0 ORDER BY `prestigeLevel` DESC, `xp` DESC LIMIT 12');
 
         $topUsers = array_map(function ($user) {
             // Add - to uuid

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -21,7 +21,7 @@
                                             <span class="px-2 py-1 text-white text-xs font-medium rounded-full" style="background-color: {{ $user->color }}">{{ $user->rank }}</span>
                                         </dd>
                                         <dd class="mt-3">
-                                            <span class="px-2 py-1 text-white text-xs font-medium rounded-full">{{ $user->xp }} XP</span>
+                                            <span class="px-2 py-1 text-white text-xs font-medium rounded-full"><i class="fa-solid fa-star"></i>{{ $user->prestigeLevel }} - {{ $user->xp }} XP</span>
                                         </dd>
                                         <dd class="mt-3">
                                             <span class="px-2 py-1 text-white text-xs font-medium rounded-full">{{ $user->coins }} Coins</span>

--- a/resources/views/stats/userstats.blade.php
+++ b/resources/views/stats/userstats.blade.php
@@ -28,7 +28,7 @@
                                         </div>
                                         <div class="flex flex-col border-t border-gray-100 p-6 text-center sm:border-0 sm:border-l">
                                             <dt class="order-2 mt-2 text-lg leading-6 font-medium text-gray-100">XP</dt>
-                                            <dd class="order-1 text-5xl font-extrabold text-orange-600">{{ $user->xp }}</dd>
+                                            <dd class="order-1 text-5xl font-extrabold text-orange-600"><i class="fa-solid fa-star"></i>{{ $user->prestigeLevel }}</dd><dd class="order-1 text-5xl font-extrabold text-orange-600">{{ $user->xp }}</dd>
                                         </div>
                                     </dl>
                                 </div>


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee706b6</samp>

Updated the website to show the prestige levels of users in the stats pages. Modified the SQL query and the HTML templates in `StatistkenController.php`, `stats.blade.php`, and `userstats.blade.php` to display the prestige level icon and number.

### WHY

The server now has a new feature called Prestige. 

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee706b6</samp>

*  Modify the SQL query and the HTML templates to display the prestige level of the users in the stats pages ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/81/files?diff=unified&w=0#diff-cba6fdfc9a2c31b44c820c572ecbba6e969ec334f10b0739d52a344eb2478ceeL14-R14), [link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/81/files?diff=unified&w=0#diff-1606e1d078b3556b885ba3d1ff991c833c059dc678d9de3e66b040e9b804428fL24-R24), [link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/81/files?diff=unified&w=0#diff-5f38810c9aec0fe3ce168d128a694e6bcc73e1ea763145cdd77f7c5b551ae80dL31-R31))
