### PR TITLE
#82 added level display

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,8 @@
+<?php
+
+if (!function_exists('getLevel')) {
+    function getLevel($xp): int
+    {
+        return intval(pow($xp / 100.0, 0.6));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "spatie/laravel-ignition": "^2.0"
     },
     "autoload": {
+        "files": [
+            "app/helpers.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -21,7 +21,7 @@
                                             <span class="px-2 py-1 text-white text-xs font-medium rounded-full" style="background-color: {{ $user->color }}">{{ $user->rank }}</span>
                                         </dd>
                                         <dd class="mt-3">
-                                            <span class="px-2 py-1 text-white text-xs font-medium rounded-full"><i class="fa-solid fa-star"></i>{{ $user->prestigeLevel }} - {{ $user->xp }} XP</span>
+                                            <span class="px-2 py-1 text-white text-xs font-extrabold rounded-full"><span class="text-[#30ff29]">{{ getLevel($user->xp) }}</span> <span class="text-[#f1c40f]"><i class="fa-solid fa-star pr-[2px]"></i>{{ $user->prestigeLevel }}</span></span>
                                         </dd>
                                         <dd class="mt-3">
                                             <span class="px-2 py-1 text-white text-xs font-medium rounded-full">{{ $user->coins }} Coins</span>

--- a/resources/views/stats/userstats.blade.php
+++ b/resources/views/stats/userstats.blade.php
@@ -28,7 +28,11 @@
                                         </div>
                                         <div class="flex flex-col border-t border-gray-100 p-6 text-center sm:border-0 sm:border-l">
                                             <dt class="order-2 mt-2 text-lg leading-6 font-medium text-gray-100">XP</dt>
-                                            <dd class="order-1 text-5xl font-extrabold text-orange-600"><i class="fa-solid fa-star"></i>{{ $user->prestigeLevel }}</dd><dd class="order-1 text-5xl font-extrabold text-orange-600">{{ $user->xp }}</dd>
+                                            <dd class="order-1 text-5xl font-extrabold text-orange-600">
+                                                <span class="text-[#30ff29]">{{ getLevel($user->xp) }}</span>
+                                                <span class="text-[#f1c40f]"><i class="fa-solid fa-star pr-[2px]"></i>{{ $user->prestigeLevel }}</span>
+                                            </dd>
+                                            <dd class="order-1 text-5xl font-extrabold text-orange-600">{{ $user->xp }}</dd>
                                         </div>
                                     </dl>
                                 </div>


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d27e80d</samp>

This pull request adds a new feature to show the user's level and prestige level based on their XP. It introduces a new helper function `getLevel` in `app/helpers.php` and modifies the views `stats.blade.php` and `userstats.blade.php` to use the function and display the level information.

### WHY

Added level display to the list and detailed player stats.

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d27e80d</samp>

*  Add a helper function `getLevel` to calculate the user's level based on XP ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/86/files?diff=unified&w=0#diff-e7252f2afe8038968ede9adb0cc88dd0337201cadb82d2e1d376d0638b7aeb5eR1-R8))
*  Update the views `stats.blade.php` and `userstats.blade.php` to display the user's level and prestige level instead of just XP ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/86/files?diff=unified&w=0#diff-1606e1d078b3556b885ba3d1ff991c833c059dc678d9de3e66b040e9b804428fL24-R24), [link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/86/files?diff=unified&w=0#diff-5f38810c9aec0fe3ce168d128a694e6bcc73e1ea763145cdd77f7c5b551ae80dL31-R35))
*  Apply consistent styling and spacing to the level and prestige elements in both views ([link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/86/files?diff=unified&w=0#diff-1606e1d078b3556b885ba3d1ff991c833c059dc678d9de3e66b040e9b804428fL24-R24), [link](https://github.com/SkyRealmDE/SkyRealmDE-Website/pull/86/files?diff=unified&w=0#diff-5f38810c9aec0fe3ce168d128a694e6bcc73e1ea763145cdd77f7c5b551ae80dL31-R35))
